### PR TITLE
Update FloatTestSuite.hx

### DIFF
--- a/Source/tests/FloatTestSuite.hx
+++ b/Source/tests/FloatTestSuite.hx
@@ -45,7 +45,9 @@ class FloatTestSuite extends TestSuite {
     //------------------------------
 
     public function baseline():Void {
+        var n = 0.0;
         for (i in 0 ... loops) {
+            n = 0.0;
         }
     }
 
@@ -55,28 +57,30 @@ class FloatTestSuite extends TestSuite {
     //------------------------------
 
     public function addition():Void {
+        var n = 0.0;
         for (i in 0 ... loops) {
-            var n:Float = i + 0.1;
+            n = i + 0.1;
         }
     }
 
     public function subtraction():Void {
+        var n = 0.0;
         for (i in 0 ... loops) {
-            var n:Float = i - 0.1;
+            n = i - 0.1;
         }
     }
 
     public function division():Void {
+        var n = 0.0;
         for (i in 0 ... loops) {
-            var n:Float = i / 1000;
+            n = i / 1000;
         }
     }
 
     public function multiplication():Void {
+        var n = 0.0;
         for (i in 0 ... loops) {
-            var n:Float = i * 0.001;
+            n = i * 0.001;
         }
     }
-
 }
-


### PR DESCRIPTION
I would change the test this way for the following reason:
- the current baseline might be optimized out entirely
- the variable definition inside the loop might influence the results (and the baseline doesn't contain it)
- the assignments inside the loops might also be optimized out since they have no side effects
